### PR TITLE
#53 Do not override obj to None.

### DIFF
--- a/gcp_storage_emulator/handlers/objects.py
+++ b/gcp_storage_emulator/handlers/objects.py
@@ -238,10 +238,10 @@ def upload_partial(request, response, storage, *args, **kwargs):
         obj = storage.get_resumable_file_obj(upload_id)
         obj = _checksums(request.data, obj)
         obj["size"] = str(len(request.data))
-        obj = storage.create_file(
+        storage.create_file(
             obj["bucket"], obj["name"], request.data, obj, upload_id
         )
-        return response.json(obj)
+        response.json(obj)
     except NotFound:
         response.status = HTTPStatus.NOT_FOUND
     except Conflict as err:

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -225,6 +225,18 @@ class ObjectsTests(ServerBaseCase):
             with open(test_binary, "rb") as orig_file:
                 self.assertEqual(temp_file.read(), orig_file.read())
 
+    def test_upload_from_file(self):
+        test_binary = os.path.join(
+            os.path.dirname(os.path.abspath(__file__)), "test_binary.png"
+        )
+        file_name = "test_binary.png"
+
+        bucket = self._client.create_bucket("testbucket")
+        blob = bucket.blob(file_name)
+        with open(test_binary, "rb") as filehandle:
+            blob.upload_from_file(filehandle)
+            self.assertTrue(blob.id.startswith("testbucket/test_binary.png/"))
+
     def test_get(self):
         file_name = "testblob-name.txt"
         content = "this is the content of the file\n"


### PR DESCRIPTION
@oittaa 

When calling storage.create_file, create_file does not return a value, so implicitly None is assigned to obj, which is then used to build the response json.  This in turn is used to build the _properties of the blob on the client side, resulting in the properties not being assessible.

Add unittest to ensure resulting blob still has accessible properties.  Even though upload_from_file is often called in the unittests, the resulting properties are never asserted. The new unittest simply checks a property explicitly afterwards. Running just the test fails. Running the test after patching the upload_from_file method works.

Baire