### PR TITLE
support gcloud storage java sdk

### DIFF
--- a/gcp_storage_emulator/handlers/objects.py
+++ b/gcp_storage_emulator/handlers/objects.py
@@ -96,6 +96,7 @@ def _checksums(content, file_obj):
 
 def _patch_object(obj, metadata):
     if metadata:
+        obj["metageneration"] = str(int(obj["metageneration"]) + 1)
         for key in _WRITABLE_FIELDS:
             val = metadata.get(key)
             if val is not None:

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -400,10 +400,12 @@ class ObjectsTests(ServerBaseCase):
         blob.content_encoding = "gzip"
         blob.upload_from_string(content)
         blob.reload()
+        metageneration = blob.metageneration
         self.assertEqual(blob.content_encoding, "gzip")
         blob.content_encoding = ""
         blob.patch()
         blob.reload()
+        self.assertNotEqual(blob.metageneration, metageneration)
         self.assertEqual(blob.content_encoding, "")
 
     def test_valid_md5_hash(self):


### PR DESCRIPTION
by default, gloud storage java sdk would send HTTP request in the following ways that was not supported by the emulator right now:

1. use 'x-http-method-override' header to override the http methods. For example, if the request method is actually 'PATCH', the standard http method is 'POST' with 'x-http-method-override' header value set as 'PATCH'.
2. use chunked encoding to transfer data without 'Content-Length' header.
3. use 'gzip' content encoding to compress the data.

This commit added support to all above. It also increments the metageneration when the object metadata is patched/updated.