### PR TITLE
fixed create_bucket subcommand exits 0

### DIFF
--- a/gcp_storage_emulator/__main__.py
+++ b/gcp_storage_emulator/__main__.py
@@ -100,7 +100,7 @@ def main(args=sys.argv[1:], test_mode=False):
     if args.subcommand == "create_bucket":
         storage = Storage(data_dir=args.data_dir)
         create_bucket(args.name, storage)
-        sys.exit(1)
+        sys.exit(0)
 
     root = logging.getLogger("")
     stream_handler = logging.StreamHandler()


### PR DESCRIPTION
I wanna execute a command like below in the docker. but create_bucket subcommand exits 1.
So the docker finishes as a failure.

```
sh -c "gcp-storage-emulator -d /storage create_bucket bucket && gcp-storage-emulator -d /storage start"
```