### PR TITLE
If content is `None`, save it as `b""`

### DIFF
--- a/gcp_storage_emulator/handlers/objects.py
+++ b/gcp_storage_emulator/handlers/objects.py
@@ -263,7 +263,7 @@ def upload_partial(request, response, storage, *args, **kwargs):
                 response["Range"] = "bytes=0-{}".format(m_dict["end"])
                 return
         else:
-            data = request.data
+            data = request.data or b""
 
         obj = _checksums(data, obj)
         obj["size"] = str(len(data))

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -772,6 +772,14 @@ class ObjectsTests(ServerBaseCase):
         self.assertEqual(len(fetched_content), len(content))
         self.assertEqual(fetched_content, content)
 
+    def test_empty_blob(self):
+        bucket = self._client.create_bucket("testbucket")
+        bucket.blob("empty_blob").open("w").close()
+
+        blob = bucket.get_blob("empty_blob")
+        fetched_content = blob.download_as_bytes()
+        self.assertEqual(fetched_content, b"")
+
 
 class HttpEndpointsTest(ServerBaseCase):
     """Tests for the HTTP endpoints defined by server.HANDLERS."""


### PR DESCRIPTION
Fixes #108