### PR TITLE
Added Context Manager to Server Class

### DIFF
--- a/src/gcp_storage_emulator/server.py
+++ b/src/gcp_storage_emulator/server.py
@@ -407,6 +407,14 @@ class Server(object):
             buckets.create_bucket(default_bucket, self._storage)
         self._api = APIThread(host, port, self._storage)
 
+    # Context Manager
+    def __enter__(self):
+        self.start()
+        return self
+
+    def __exit__(self, *args):
+        self.stop()
+
     def start(self):
         self._api.start()
         self._api.is_running.wait()  # Start the API thread


### PR DESCRIPTION
This project is really awesome tried this and solved the exact problem I was facing; I'm wondering if you'd be happy with adding context manager support to `Server` class. 
Like currently in documentation, it's given as : 
```python
from gcp_storage_emulator.server import create_server

server = create_server("localhost", 9023, in_memory=False)

server.start()
# ........
server.stop()
```

But after adding context manager support, it'd look like : 
```python
from gcp_storage_emulator.server import Server

with Server("localhost", 9023, in_memory=False) as server:
     # .........
     # ........
```

As this might look like a small change, but this would be really convenient.
Also thanks for such a nice project 😁 