### PR TITLE
Remove dependency pins

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -57,8 +57,8 @@ setup(
         ],
     },
     install_requires=[
-        "fs==2.4.16",
-        "google-crc32c==1.3.0",
+        "fs",
+        "google-crc32c",
     ],
     python_requires=">=3.7",
 )


### PR DESCRIPTION
`google-crc32c` is pinned to an old version that doesn't provide py 3.11 wheels (so falls back to the much slower python only implementation). There's a [dependabot PR](https://github.com/oittaa/gcp-storage-emulator/pull/200) for it, but it's usually better for libraries (I use this more like a library in another project's venv, but maybe others see it as an "app"?) to not have exact pins, so this PR removes them. That seemed simpler than ranges and not too likely to break things.

This should hopefully reduce the dependabot PR burden for you a little bit, but only to `setup.py`, not `requirements-dev.txt`.
