### PR TITLE
Add functionality for content-disposition option in signed url.

### DIFF
--- a/src/gcp_storage_emulator/handlers/objects.py
+++ b/src/gcp_storage_emulator/handlers/objects.py
@@ -471,6 +471,9 @@ def download(request, response, storage, *args, **kwargs):
             hash_header = "crc32c={},md5={}".format(obj["crc32c"], obj["md5Hash"])
             response[_HASH_HEADER] = hash_header
 
+        if 'response-content-disposition' in request.query:
+            response['Content-Disposition'] = request.query['response-content-disposition'][0]
+
         response.write_file(file, content_type=obj.get("contentType"))
     except NotFound:
         response.status = HTTPStatus.NOT_FOUND


### PR DESCRIPTION
The signed url functionality allows specifying a content-disposition header that is returned when the URL is hit, allowing the ability to specify from the URL what filename should be used and to tell a browser to download instead of display the object.