### PR TITLE
Java client api setup targeting localhost

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ Storage storage() {
         return localhostOptions().getService();
     }
 StorageOptions localhostOptions() {
-        return HttpStorageOptions.newBuilder().setHost(TestBase.emulatorHost)
+        return HttpStorageOptions.newBuilder().setHost("localhost:9023")
             .setHeaderProvider(UserAgentHeaderProvider(GcpStorageAutoConfiguration.class))
             .setProjectId("test-project-id")
             .build();

--- a/README.md
+++ b/README.md
@@ -109,6 +109,27 @@ for blob in bucket.list_blobs():
 server.stop()
 ```
 
+
+## Java
+
+The GCP Java storage api uses the default google apis endpoint and to change it to another host it is necessary
+to alter the default creation of the storage client object.
+
+This is an example targeting localhost on port 9023:
+
+```java
+Storage storage() {
+        return localhostOptions().getService();
+    }
+StorageOptions localhostOptions() {
+        return HttpStorageOptions.newBuilder().setHost(TestBase.emulatorHost)
+            .setHeaderProvider(UserAgentHeaderProvider(GcpStorageAutoConfiguration.class))
+            .setProjectId("test-project-id")
+            .build();
+    }
+```
+
+
 ## Docker
 
 Pull the Docker image.


### PR DESCRIPTION
Using the GCP Java api for storage, it is not obvious how to set it up to target the emulator running locally or elsewhere. 
This is a short example on how to do that. 