### PR TITLE
adds support for metadata during object creation

### DIFF
--- a/src/gcp_storage_emulator/handlers/objects.py
+++ b/src/gcp_storage_emulator/handlers/objects.py
@@ -227,6 +227,7 @@ def _create_resumable_upload(request, response, storage):
         object_id,
         content_type,
         content_length,
+        metadata={**(request.data or {}), "name": object_id},
     )
     id = storage.create_resumable_upload(
         request.params["bucket_name"],

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -944,6 +944,24 @@ class ObjectsTests(ServerBaseCase):
         self.assertEqual(blob.name, file_name)
         self.assertEqual(blob.download_as_bytes(), content)
 
+    def test_upload_from_file_with_metadata(self):
+        file_name = "test.json"
+        content = b'[{"a": 1}]'
+        bucket = self._client.create_bucket("testbucket")
+        blob = bucket.blob(file_name)
+        blob.metadata = {"foo": "bar"}
+
+        with NamedTemporaryFile() as temp_file:
+            temp_file.write(content)
+            temp_file.flush()
+            temp_file.seek(0)
+            blob.upload_from_file(temp_file, content_type="application/json")
+
+        blob = bucket.get_blob(file_name)
+        self.assertEqual(blob.name, file_name)
+        self.assertEqual(blob.download_as_bytes(), content)
+        self.assertEqual(blob.metadata, {"foo": "bar"})
+
 
 class HttpEndpointsTest(ServerBaseCase):
     """Tests for the HTTP endpoints defined by server.HANDLERS."""


### PR DESCRIPTION
New objects being created via the `google.cloud.storage.Blob` api that have had `metadata` set on the object via `blob.metadata` are not having the metadata persisted in the emulator.

The upload process from the google cloud library initiates the upload with a POST to `/b/(?P<bucket_name>)/o?uploadType=resumable` with a `Content-Type: application/json` header the `metadata` stored in the payload. The emulator is pulling the object name from the payload but it is not piping the metadata through to object creation