### PR TITLE
add permissive options response from all endpoints

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -150,3 +150,6 @@ cython_debug/
 
 .cloudstorage
 .idea
+
+.envrc
+.direnv

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -76,3 +76,13 @@ class MainHttpEndpointsTest(ServerBaseCase):
         response = requests.get(url)
         self.assertEqual(response.status_code, 501)
         self.assertEqual(response.content, "".encode("utf-8"))
+
+    def test_options(self):
+        url = self._url("/")
+        response = requests.options(url)
+        self.assertEqual(response.status_code, 200)
+        self.assertIn("access-control-allow-methods", response.headers)
+        self.assertTrue(
+            "GET,POST,PUT,PATCH,DELETE,OPTIONS"
+            in response.headers["access-control-allow-methods"]
+        )


### PR DESCRIPTION
This PR adds an OPTIONS handler to all endpoints that add permissive CORS headers to all endpoints.

This supercedes #189.

I did attempt to fix the tests in @palewire's original PR, however the implementation significantly changed.
