### PR TITLE
Add matchGlob listing and Host-based base URLs

### DIFF
--- a/src/gcp_storage_emulator/exceptions.py
+++ b/src/gcp_storage_emulator/exceptions.py
@@ -4,3 +4,7 @@ class NotFound(Exception):
 
 class Conflict(Exception):
     pass
+
+
+class BadRequest(Exception):
+    pass

--- a/src/gcp_storage_emulator/gcs_glob.py
+++ b/src/gcp_storage_emulator/gcs_glob.py
@@ -1,0 +1,128 @@
+"""GCS objects.list matchGlob pattern matching.
+
+Syntax:
+https://cloud.google.com/storage/docs/json_api/v1/objects/list#list-object-glob
+"""
+
+from __future__ import annotations
+
+import re
+from functools import lru_cache
+from typing import List
+
+
+def _split_brace_options(inner: str) -> List[str]:
+    options: List[str] = []
+    current: List[str] = []
+    depth = 0
+    for ch in inner:
+        if ch == "{":
+            depth += 1
+            current.append(ch)
+        elif ch == "}":
+            depth -= 1
+            current.append(ch)
+        elif ch == "," and depth == 0:
+            options.append("".join(current))
+            current = []
+        else:
+            current.append(ch)
+    options.append("".join(current))
+    return options
+
+
+def expand_braces(pattern: str) -> List[str]:
+    """Expand ``{a,b}`` alternatives (GCS forbids ``/`` and ``**`` inside braces)."""
+    results: List[str] = []
+
+    def helper(s: str) -> None:
+        start = s.find("{")
+        if start == -1:
+            results.append(s)
+            return
+        depth = 0
+        end = -1
+        for i in range(start, len(s)):
+            if s[i] == "{":
+                depth += 1
+            elif s[i] == "}":
+                depth -= 1
+                if depth == 0:
+                    end = i
+                    break
+        if end == -1:
+            results.append(s)
+            return
+        before = s[:start]
+        after = s[end + 1 :]
+        for option in _split_brace_options(s[start + 1 : end]):
+            helper(before + option + after)
+
+    helper(pattern)
+    return results
+
+
+def _consume_character_class(pattern: str, start: int) -> tuple:
+    """Parse a ``[...]`` class starting at *start*. Returns (regex, next_index)."""
+    n = len(pattern)
+    j = start + 1
+    if j < n and pattern[j] in ("!", "^"):
+        j += 1
+    if j < n and pattern[j] == "]":
+        j += 1
+    while j < n and pattern[j] != "]":
+        j += 1
+    if j >= n:
+        return re.escape(pattern[start]), start + 1
+    cls = pattern[start : j + 1]
+    if cls.startswith("[!"):
+        cls = "[^" + cls[2:]
+    return cls, j + 1
+
+
+def _consume_star(pattern: str, start: int) -> tuple:
+    """Parse ``*``, ``**``, or ``**/`` at *start*. Returns (regex, next_index)."""
+    n = len(pattern)
+    if start + 1 < n and pattern[start + 1] == "*":
+        if start + 2 < n and pattern[start + 2] == "/":
+            # **/ — zero or more path segments ending in /
+            return "(?:.*/)?", start + 3
+        return ".*", start + 2
+    return "[^/]*", start + 1
+
+
+def _glob_to_regex(pattern: str) -> re.Pattern:
+    i = 0
+    n = len(pattern)
+    out: List[str] = ["^"]
+    while i < n:
+        ch = pattern[i]
+        if ch == "\\" and i + 1 < n:
+            out.append(re.escape(pattern[i + 1]))
+            i += 2
+        elif ch == "*":
+            piece, i = _consume_star(pattern, i)
+            out.append(piece)
+        elif ch == "?":
+            out.append("[^/]")
+            i += 1
+        elif ch == "[":
+            piece, i = _consume_character_class(pattern, i)
+            out.append(piece)
+        else:
+            out.append(re.escape(ch))
+            i += 1
+    out.append("$")
+    return re.compile("".join(out))
+
+
+@lru_cache(maxsize=256)
+def _compiled_patterns(pattern: str) -> tuple:
+    return tuple(_glob_to_regex(part) for part in expand_braces(pattern))
+
+
+def gcs_glob_match(pattern: str, name: str) -> bool:
+    """Return True if *name* matches the GCS *matchGlob* pattern."""
+    if not pattern:
+        return False
+    return any(regex.match(name) is not None for regex in _compiled_patterns(pattern))

--- a/src/gcp_storage_emulator/handlers/objects.py
+++ b/src/gcp_storage_emulator/handlers/objects.py
@@ -14,7 +14,7 @@ from http import HTTPStatus
 
 import google_crc32c
 
-from gcp_storage_emulator.exceptions import Conflict, NotFound
+from gcp_storage_emulator.exceptions import BadRequest, Conflict, NotFound
 
 logger = logging.getLogger("api.object")
 
@@ -357,10 +357,17 @@ def ls(request, response, storage, *args, **kwargs):
     delimiter = (
         request.query.get("delimiter")[0] if request.query.get("delimiter") else None
     )
+    match_glob = (
+        request.query.get("matchGlob")[0] if request.query.get("matchGlob") else None
+    )
     try:
-        files, prefixes = storage.get_file_list(bucket_name, prefix, delimiter)
+        files, prefixes = storage.get_file_list(
+            bucket_name, prefix, delimiter, match_glob
+        )
     except NotFound:
         response.status = HTTPStatus.NOT_FOUND
+    except BadRequest:
+        response.status = HTTPStatus.BAD_REQUEST
     else:
         response.json({"kind": "storage#object", "prefixes": prefixes, "items": files})
 

--- a/src/gcp_storage_emulator/server.py
+++ b/src/gcp_storage_emulator/server.py
@@ -235,9 +235,16 @@ class Request(object):
         self._path = request_handler.path
         self._request_handler = request_handler
         self._server_address = request_handler.server.server_address
-        self._base_url = "http://{}:{}".format(
-            self._server_address[0], self._server_address[1]
-        )
+        # Prefer the client-facing Host header so resumable upload Location /
+        # mediaLink URLs work in Docker (bind address is often 0.0.0.0).
+        # https://github.com/oittaa/gcp-storage-emulator/issues/210
+        host = request_handler.headers.get("Host")
+        if host:
+            self._base_url = "http://{}".format(host)
+        else:
+            self._base_url = "http://{}:{}".format(
+                self._server_address[0], self._server_address[1]
+            )
         self._full_url = self._base_url + self._path
         self._parsed_url = urlparse(self._full_url)
         self._query = parse_qs(self._parsed_url.query)

--- a/src/gcp_storage_emulator/storage.py
+++ b/src/gcp_storage_emulator/storage.py
@@ -7,7 +7,8 @@ from hashlib import sha256
 from pathlib import Path
 from typing import Dict, List, Optional, Set
 
-from gcp_storage_emulator.exceptions import Conflict, NotFound
+from gcp_storage_emulator.exceptions import BadRequest, Conflict, NotFound
+from gcp_storage_emulator.gcs_glob import gcs_glob_match
 from gcp_storage_emulator.settings import STORAGE_BASE, STORAGE_DIR
 
 # Real buckets can't start with an underscore
@@ -229,60 +230,60 @@ class Storage:
 
         return self.buckets.get(bucket_name)
 
-    def get_file_list(self, bucket_name, prefix=None, delimiter=None):
-        """Lists all the blobs in the bucket that begin with the prefix.
+    def get_file_list(self, bucket_name, prefix=None, delimiter=None, match_glob=None):
+        """Lists objects in a bucket with optional prefix, delimiter, and matchGlob.
 
-        This can be used to list all blobs in a "folder", e.g. "public/".
+        matchGlob follows the GCS objects.list glob syntax:
+        https://cloud.google.com/storage/docs/json_api/v1/objects/list#list-object-glob
 
-        The delimiter argument can be used to restrict the results to only the
-        "files" in the given "folder". Without the delimiter, the entire tree under
-        the prefix is returned. For example, given these blobs:
-
-            a/1.txt
-            a/b/2.txt
-
-        If you just specify prefix = 'a', you'll get back:
-
-            a/1.txt
-            a/b/2.txt
-
-        However, if you specify prefix='a' and delimiter='/', you'll get back:
-
-            a/1.txt
-
-        Additionally, the same request will return blobs.prefixes populated with:
-
-            a/b/
-
-        Source: https://cloud.google.com/storage/docs/listing-objects#storage-list-objects-python
+        When matchGlob is set, delimiter must be omitted or ``/``. Matching object
+        names are returned in items; with delimiter ``/``, matching object prefixes
+        are returned in prefixes.
         """
 
         if bucket_name not in self.buckets:
             raise NotFound
 
-        prefix_len = 0
-        prefixes = []
+        if match_glob is not None and delimiter is not None and delimiter != "/":
+            raise BadRequest(
+                "When listing with a glob pattern, the only supported delimiter is '/'."
+            )
+
         bucket_objects = self.objects.get(bucket_name, {})
-        if prefix:
-            prefix_len = len(prefix)
-            objs = list(
-                file_object
-                for file_name, file_object in bucket_objects.items()
-                if file_name.startswith(prefix)
-                and (not delimiter or delimiter not in file_name[prefix_len:])
-            )
-        else:
-            objs = list(bucket_objects.values())
+        candidates = [
+            (file_name, file_object)
+            for file_name, file_object in bucket_objects.items()
+            if prefix is None or file_name.startswith(prefix)
+        ]
+
+        if match_glob is not None:
+            candidates = [
+                (file_name, file_object)
+                for file_name, file_object in candidates
+                if gcs_glob_match(match_glob, file_name)
+            ]
+
+        prefix_len = len(prefix) if prefix else 0
+        objs = []
+        prefixes = set()
+
         if delimiter:
-            prefixes = list(
-                file_name[:prefix_len]
-                + file_name[prefix_len:].split(delimiter, 1)[0]
-                + delimiter
-                for file_name in list(bucket_objects)
-                if file_name.startswith(prefix or "")
-                and delimiter in file_name[prefix_len:]
-            )
-        return objs, prefixes
+            for file_name, file_object in candidates:
+                rest = file_name[prefix_len:]
+                if delimiter in rest:
+                    head, _sep, _tail = rest.partition(delimiter)
+                    prefixes.add(file_name[:prefix_len] + head + delimiter)
+                else:
+                    objs.append(file_object)
+            if match_glob is not None:
+                prefixes = {
+                    folder for folder in prefixes if gcs_glob_match(match_glob, folder)
+                }
+        else:
+            objs = [file_object for _name, file_object in candidates]
+
+        objs.sort(key=lambda obj: obj.get("name") or "")
+        return objs, sorted(prefixes)
 
     def create_bucket(self, bucket_name, bucket_obj):
         """Create a bucket object representation and save it to the current fs

--- a/tests/test_gcs_glob.py
+++ b/tests/test_gcs_glob.py
@@ -1,0 +1,53 @@
+from unittest import TestCase
+from unittest.mock import MagicMock
+
+from gcp_storage_emulator.gcs_glob import expand_braces, gcs_glob_match
+from gcp_storage_emulator.server import Request
+
+
+class GcsGlobTests(TestCase):
+    def test_expand_braces(self):
+        self.assertEqual(
+            sorted(expand_braces("foo/{a,b}")),
+            ["foo/a", "foo/b"],
+        )
+        self.assertEqual(
+            sorted(expand_braces("**/{foobar,baz}")),
+            ["**/baz", "**/foobar"],
+        )
+
+    def test_match_glob_examples(self):
+        blob_names = ["foo/bar", "foo/baz", "foo/foobar", "foobar"]
+        expected = {
+            "foo*bar": ["foobar"],
+            "foo**bar": ["foo/bar", "foo/foobar", "foobar"],
+            "**/foobar": ["foo/foobar", "foobar"],
+            "*/ba[rz]": ["foo/bar", "foo/baz"],
+            "*/ba[!a-y]": ["foo/baz"],
+            "**/{foobar,baz}": ["foo/baz", "foo/foobar", "foobar"],
+            "foo/{foo*,*baz}": ["foo/baz", "foo/foobar"],
+        }
+        for pattern, names in expected.items():
+            matched = [name for name in blob_names if gcs_glob_match(pattern, name)]
+            self.assertEqual(matched, names, pattern)
+
+
+class RequestBaseUrlTests(TestCase):
+    def test_base_url_prefers_host_header(self):
+        handler = MagicMock()
+        handler.path = "/upload/storage/v1/b/bucket/o?uploadType=resumable"
+        handler.headers = {"Host": "storage.example.test:9023"}
+        handler.server.server_address = ("0.0.0.0", 9023)
+
+        request = Request(handler, "POST")
+        self.assertEqual(request.base_url, "http://storage.example.test:9023")
+        self.assertNotIn("0.0.0.0", request.base_url)
+
+    def test_base_url_falls_back_to_bind_address(self):
+        handler = MagicMock()
+        handler.path = "/"
+        handler.headers = {}
+        handler.server.server_address = ("127.0.0.1", 8080)
+
+        request = Request(handler, "GET")
+        self.assertEqual(request.base_url, "http://127.0.0.1:8080")

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -601,6 +601,48 @@ class ObjectsTests(ServerBaseCase):
 
         self._assert_blob_list(blobs, [blob_1, blob_2])
 
+    def test_list_blobs_with_match_glob(self):
+        bucket = self._client.create_bucket("bucket_name")
+        for name in ["foo/bar", "foo/baz", "foo/foobar", "foobar"]:
+            bucket.blob(name).upload_from_string("helloworld")
+
+        expected = {
+            "foo*bar": ["foobar"],
+            "foo**bar": ["foo/bar", "foo/foobar", "foobar"],
+            "**/foobar": ["foo/foobar", "foobar"],
+            "*/ba[rz]": ["foo/bar", "foo/baz"],
+            "*/ba[!a-y]": ["foo/baz"],
+            "**/{foobar,baz}": ["foo/baz", "foo/foobar", "foobar"],
+            "foo/{foo*,*baz}": ["foo/baz", "foo/foobar"],
+        }
+        for match_glob, names in expected.items():
+            blobs = list(self._client.list_blobs(bucket, match_glob=match_glob))
+            self.assertEqual([blob.name for blob in blobs], names, match_glob)
+
+    def test_list_blobs_with_match_glob_and_delimiter(self):
+        bucket = self._client.create_bucket("bucket_name")
+        for name in ["all/foo/bar", "foo/baz", "foo/389_bar", "bar", "baz"]:
+            bucket.blob(name).upload_from_string("helloworld")
+
+        expected = {
+            "foo*bar": [],
+            "**/bar": ["bar"],
+            "**ba[rz]": ["bar", "baz"],
+            "*ba[!a-y]": ["baz"],
+            "**/{foobar,baz}": ["baz"],
+            "*{foo*,*baz}": ["baz"],
+        }
+        for match_glob, names in expected.items():
+            blobs = list(
+                self._client.list_blobs(bucket, match_glob=match_glob, delimiter="/")
+            )
+            self.assertEqual([blob.name for blob in blobs], names, match_glob)
+
+    def test_list_blobs_match_glob_wrong_delimiter(self):
+        bucket = self._client.create_bucket("bucket_name")
+        with self.assertRaises(BadRequest):
+            list(self._client.list_blobs(bucket, delimiter="*", match_glob="*.pdf"))
+
     def test_list_blobs_with_prefix_and_delimiter(self):
         bucket = self._client.create_bucket("bucket_name")
 

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -2,7 +2,7 @@ import json
 import os
 from unittest import TestCase as BaseTestCase
 
-from gcp_storage_emulator.exceptions import NotFound
+from gcp_storage_emulator.exceptions import BadRequest, NotFound
 from gcp_storage_emulator.settings import STORAGE_BASE, STORAGE_DIR
 from gcp_storage_emulator.storage import Storage
 
@@ -119,6 +119,68 @@ class StorageOSFSTests(BaseTestCase):
             "a_bucket_name", "file_name.png", file_obj
         )
         self.assertNotEqual(file_id_1, file_id_2)
+
+    def test_get_file_list_match_glob(self):
+        content = b"Helloworld"
+        for name in ["foo/bar", "foo/baz", "foo/foobar", "foobar"]:
+            self.storage.create_file(
+                "a_bucket_name",
+                name,
+                content,
+                {"bucket": "a_bucket_name", "name": name},
+            )
+
+        expected = {
+            "foo*bar": ["foobar"],
+            "foo**bar": ["foo/bar", "foo/foobar", "foobar"],
+            "**/foobar": ["foo/foobar", "foobar"],
+            "*/ba[rz]": ["foo/bar", "foo/baz"],
+            "*/ba[!a-y]": ["foo/baz"],
+            "**/{foobar,baz}": ["foo/baz", "foo/foobar", "foobar"],
+            "foo/{foo*,*baz}": ["foo/baz", "foo/foobar"],
+        }
+        for match_glob, names in expected.items():
+            file_objs, prefixes = self.storage.get_file_list(
+                "a_bucket_name", match_glob=match_glob
+            )
+            self.assertEqual([obj["name"] for obj in file_objs], names, match_glob)
+            self.assertEqual(prefixes, [])
+
+    def test_get_file_list_match_glob_with_slash_delimiter(self):
+        content = b"Helloworld"
+        for name in ["all/foo/bar", "foo/baz", "foo/389_bar", "bar", "baz"]:
+            self.storage.create_file(
+                "a_bucket_name",
+                name,
+                content,
+                {"bucket": "a_bucket_name", "name": name},
+            )
+
+        expected = {
+            "foo*bar": [],
+            "**/bar": ["bar"],
+            "**ba[rz]": ["bar", "baz"],
+            "*ba[!a-y]": ["baz"],
+            "**/{foobar,baz}": ["baz"],
+            "*{foo*,*baz}": ["baz"],
+        }
+        for match_glob, names in expected.items():
+            file_objs, _prefixes = self.storage.get_file_list(
+                "a_bucket_name", match_glob=match_glob, delimiter="/"
+            )
+            self.assertEqual([obj["name"] for obj in file_objs], names, match_glob)
+
+    def test_get_file_list_match_glob_rejects_non_slash_delimiter(self):
+        self.storage.create_file(
+            "a_bucket_name",
+            "file.png",
+            b"x",
+            {"bucket": "a_bucket_name", "name": "file.png"},
+        )
+        with self.assertRaises(BadRequest):
+            self.storage.get_file_list(
+                "a_bucket_name", delimiter="*", match_glob="*.png"
+            )
 
     def test_create_file_for_resumable_upload(self):
         test_file = os.path.join(


### PR DESCRIPTION
Implement GCS objects.list matchGlob with a small stdlib glob matcher (brace expansion, **, *, ?, character classes). Enforce delimiter=/ when matchGlob is set, apply prefix then glob then directory mode, and filter resulting prefixes by the glob.

Build request base_url from the Host header so resumable upload Location and mediaLink work in Docker instead of advertising 0.0.0.0.