### PR TITLE
Fix objects.rewrite response to match GCS JSON API

### DIFF
--- a/src/gcp_storage_emulator/handlers/objects.py
+++ b/src/gcp_storage_emulator/handlers/objects.py
@@ -443,12 +443,16 @@ def rewrite(request, response, storage, *args, **kwargs):
             file,
             dest_obj,
         )
+        # Official rewrite response schema:
+        # https://cloud.google.com/storage/docs/json_api/v1/objects/rewrite
+        size = str(dest_obj["size"])
         response.json(
             {
-                "resource": dest_obj,
-                "written": dest_obj["size"],
-                "size": dest_obj["size"],
+                "kind": "storage#rewriteResponse",
+                "totalBytesRewritten": size,
+                "objectSize": size,
                 "done": True,
+                "resource": dest_obj,
             }
         )
     except NotFound:

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -682,6 +682,45 @@ class ObjectsTests(ServerBaseCase):
         with self.assertRaises(NotFound):
             bucket.rename_blob(blob_1, "c/d.txt")
 
+    def test_blob_rewrite_response_shape(self):
+        """Python client requires totalBytesRewritten/objectSize (issue #305)."""
+        content = b"rewrite-me-please"
+        bucket = self._client.create_bucket("rewrite_bucket")
+        source = bucket.blob("src/file.txt")
+        source.upload_from_string(content)
+
+        dest = bucket.blob("dst/file.txt")
+        token, bytes_rewritten, total_bytes = dest.rewrite(source)
+
+        self.assertIsNone(token)
+        self.assertEqual(bytes_rewritten, len(content))
+        self.assertEqual(total_bytes, len(content))
+        self.assertEqual(dest.download_as_bytes(), content)
+        self.assertEqual(dest.name, "dst/file.txt")
+
+    def test_blob_rewrite_http_response_schema(self):
+        """Raw JSON matches official storage#rewriteResponse fields."""
+        content = b"schema-check"
+        bucket = self._client.create_bucket("rewrite_http")
+        source = bucket.blob("a.txt")
+        source.upload_from_string(content)
+
+        url = (
+            "http://localhost:9023/storage/v1/b/rewrite_http/o/a.txt/"
+            "rewriteTo/b/rewrite_http/o/b.txt"
+        )
+        response = self._session.post(url)
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        self.assertEqual(data["kind"], "storage#rewriteResponse")
+        self.assertTrue(data["done"])
+        self.assertEqual(data["totalBytesRewritten"], str(len(content)))
+        self.assertEqual(data["objectSize"], str(len(content)))
+        self.assertNotIn("written", data)
+        self.assertNotIn("size", data)
+        self.assertEqual(data["resource"]["name"], "b.txt")
+        self.assertEqual(data["resource"]["bucket"], "rewrite_http")
+
     def test_compose_create_new_blob(self):
         bucket = self._client.create_bucket("compose_test")
         data_1 = b"AAA\n"


### PR DESCRIPTION
Return storage#rewriteResponse with totalBytesRewritten and objectSize (strings) instead of non-standard written/size fields. Python google-cloud-storage Blob.rewrite() requires these keys; Java clients NPE without objectSize (#305).