### PR TITLE
Return x-goog-meta-* headers on object download

### DIFF
--- a/src/gcp_storage_emulator/handlers/objects.py
+++ b/src/gcp_storage_emulator/handlers/objects.py
@@ -538,6 +538,16 @@ def download(request, response, storage, *args, **kwargs):
                 "response-content-disposition"
             ][0]
 
+        # Custom metadata is returned as x-goog-meta-* response headers on GET/HEAD.
+        # https://cloud.google.com/storage/docs/metadata#custom-metadata
+        # https://cloud.google.com/storage/docs/xml-api/reference-headers#xgoogmeta
+        custom_metadata = obj.get("metadata") or {}
+        if isinstance(custom_metadata, dict):
+            for key, value in custom_metadata.items():
+                if value is None:
+                    continue
+                response["x-goog-meta-{}".format(key)] = str(value)
+
         response.write_file(file, content_type=obj.get("contentType"))
     except NotFound:
         response.status = HTTPStatus.NOT_FOUND

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -364,6 +364,53 @@ class ObjectsTests(ServerBaseCase):
         blob.reload()
         self.assertEqual(blob.metadata, metadata)
 
+    def test_download_includes_x_goog_meta_headers(self):
+        """Custom metadata is returned as x-goog-meta-* on object download (#187)."""
+        content = b"helloworld"
+        bucket = self._client.create_bucket("testbucket")
+        blob = bucket.blob("meta-object")
+        blob.metadata = {"some": "metadata", "Color": "Pink"}
+        blob.upload_from_string(content)
+
+        # JSON API media download path
+        url = (
+            "http://localhost:9023/download/storage/v1/b/testbucket/o/"
+            "meta-object?alt=media"
+        )
+        response = self._session.get(url)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.content, content)
+        # HTTP headers are case-insensitive; requests normalizes to lowercase keys.
+        self.assertEqual(response.headers.get("x-goog-meta-some"), "metadata")
+        self.assertEqual(response.headers.get("x-goog-meta-color"), "Pink")
+
+    def test_public_path_download_includes_x_goog_meta_headers(self):
+        content = b"public-meta"
+        bucket = self._client.create_bucket("testbucket")
+        blob = bucket.blob("public-meta.txt")
+        blob.metadata = {"reviewer": "jane"}
+        blob.upload_from_string(content)
+
+        # Public / signed-URL style path: /{bucket}/{object}
+        response = self._session.get("http://localhost:9023/testbucket/public-meta.txt")
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.content, content)
+        self.assertEqual(response.headers.get("x-goog-meta-reviewer"), "jane")
+
+    def test_download_without_custom_metadata_omits_x_goog_meta_headers(self):
+        content = b"no-meta"
+        bucket = self._client.create_bucket("testbucket")
+        blob = bucket.blob("plain.txt")
+        blob.upload_from_string(content)
+
+        response = self._session.get(
+            "http://localhost:9023/download/storage/v1/b/testbucket/o/plain.txt?alt=media"
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertFalse(
+            any(name.lower().startswith("x-goog-meta-") for name in response.headers)
+        )
+
     def test_set_custom_time(self):
         content = "The quick brown fox jumps over the lazy dog\n"
         bucket = self._client.create_bucket("testbucket")


### PR DESCRIPTION
GCS documents custom metadata as x-goog-meta-KEY request and response headers on object GET/HEAD. Persist already worked via the object resource; include those pairs when serving object media (#187).