### PR TITLE
Fix multi-chunk resumable uploads with unknown total size

### DIFF
--- a/src/gcp_storage_emulator/handlers/objects.py
+++ b/src/gcp_storage_emulator/handlers/objects.py
@@ -310,23 +310,54 @@ def insert(request, response, storage, *args, **kwargs):
 
 
 def upload_partial(request, response, storage, *args, **kwargs):
-    """https://cloud.google.com/storage/docs/performing-resumable-uploads"""
+    """Handle resumable upload chunks.
+
+    https://cloud.google.com/storage/docs/performing-resumable-uploads
+
+    Content-Range forms used by clients (e.g. google-resumable-media):
+      bytes START-END/TOTAL   — chunk with known total size
+      bytes START-END/*       — chunk while total size is still unknown
+      bytes */TOTAL           — empty finalization / status with known total
+    Incomplete chunks must respond with 308 and ``Range: bytes=0-LAST``.
+    """
     upload_id = request.query.get("upload_id")[0]
-    regex = r"^\s*bytes (?P<start>[0-9]+)-(?P<end>[0-9]+)/(?P<total_size>[0-9]+)$"
-    pattern = re.compile(regex)
-    content_range = request.get_header("Content-Range", "")
-    match = pattern.fullmatch(content_range)
+    content_range = request.get_header("Content-Range", "") or ""
+    known_total = re.fullmatch(
+        r"\s*bytes (?P<start>[0-9]+)-(?P<end>[0-9]+)/(?P<total_size>[0-9]+)\s*",
+        content_range,
+    )
+    unknown_total = re.fullmatch(
+        r"\s*bytes (?P<start>[0-9]+)-(?P<end>[0-9]+)/\*\s*",
+        content_range,
+    )
     try:
         obj = storage.get_resumable_file_obj(upload_id)
-        if match:
-            m_dict = match.groupdict()
-            total_size = int(m_dict["total_size"])
-            data = storage.add_to_resumable_upload(upload_id, request.data, total_size)
+        if known_total or unknown_total:
+            m_dict = (known_total or unknown_total).groupdict()
+            start = int(m_dict["start"])
+            end = int(m_dict["end"])
+            total_size = int(m_dict["total_size"]) if known_total is not None else None
+            chunk = request.data or b""
+            if len(chunk) != end - start + 1:
+                # Tolerate empty edge cases but prefer consistent ranges.
+                pass
+            data = storage.add_to_resumable_upload(
+                upload_id,
+                chunk,
+                total_size=total_size,
+                expected_start=start,
+            )
             if data is None:
+                # Incomplete: 308 Resume Incomplete with inclusive Range.
                 response.status = GoogleHTTPStatus.RESUME_INCOMPLETE
-                response["Range"] = "bytes=0-{}".format(m_dict["end"])
+                received = storage.get_resumable_byte_count(upload_id)
+                if received > 0:
+                    response["Range"] = "bytes=0-{}".format(received - 1)
+                else:
+                    response["Range"] = "bytes=0-{}".format(end)
                 return
         else:
+            # Single-shot PUT without multi-chunk Content-Range (entire object).
             data = request.data or b""
 
         obj = _checksums(data, obj)
@@ -337,6 +368,9 @@ def upload_partial(request, response, storage, *args, **kwargs):
         response.status = HTTPStatus.NOT_FOUND
     except Conflict as err:
         _handle_conflict(response, err)
+    except BadRequest as err:
+        response.status = HTTPStatus.BAD_REQUEST
+        response.json({"error": {"message": str(err)}})
 
 
 def get(request, response, storage, *args, **kwargs):

--- a/src/gcp_storage_emulator/storage.py
+++ b/src/gcp_storage_emulator/storage.py
@@ -357,36 +357,50 @@ class Storage:
         self._write_config_to_file()
         return file_id
 
-    def add_to_resumable_upload(self, file_id, content, total_size):
-        """Add data to partial resumable download.
+    def get_resumable_byte_count(self, file_id):
+        """Return how many bytes have been received for a resumable upload so far."""
+        safe_id = self.safe_id(file_id)
+        try:
+            return len(self.get_file(RESUMABLE_DIR, safe_id, False))
+        except NotFound:
+            return 0
 
-        We can't use 'seek' to append since memory store seems to erase
-        everything in those cases. That's why the previous part is loaded
-        and rewritten again.
+    def add_to_resumable_upload(
+        self, file_id, content, total_size=None, expected_start=None
+    ):
+        """Append a chunk to a resumable upload.
 
-         Arguments:
+        Arguments:
             file_id {str} -- Resumable file id
-            content {bytes} -- Content of the file to write
-            total_size {int} -- Total object size
-
-
-        Raises:
-            NotFound: Raised when the object doesn't exist
+            content {bytes} -- Chunk content
+            total_size {int|None} -- Total object size if known; None if still
+                unknown (Content-Range ends with /*)
+            expected_start {int|None} -- Expected start offset (must match
+                current length when provided)
 
         Returns:
-            bytes -- Raw content of the file if completed, None otherwise
+            bytes -- Full object content if the upload is complete, else None
         """
         safe_id = self.safe_id(file_id)
         try:
             file_content = self.get_file(RESUMABLE_DIR, safe_id, False)
         except NotFound:
             file_content = b""
-        file_content += content
+
+        if expected_start is not None and expected_start != len(file_content):
+            raise BadRequest(
+                "Invalid Content-Range start: expected {}, got {}".format(
+                    len(file_content), expected_start
+                )
+            )
+
+        file_content += content or b""
         self._store.write_bytes(self._object_path(RESUMABLE_DIR, safe_id), file_content)
         size = len(file_content)
-        if size >= total_size:
-            return file_content[:total_size]
-        return None
+        # Incomplete while total is unknown, or while we have not received all bytes.
+        if total_size is None or size < total_size:
+            return None
+        return file_content[:total_size]
 
     def get_file_obj(self, bucket_name, file_name):
         """Gets the meta information for a file within a bucket

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -975,6 +975,39 @@ class ObjectsTests(ServerBaseCase):
         self.assertEqual(len(fetched_content), len(content))
         self.assertEqual(fetched_content, content)
 
+    def test_resumable_chunked_write_via_blob_open(self):
+        """Multi-chunk streaming write (issue #301).
+
+        google-resumable-media sends Content-Range: bytes START-END/* until the
+        final chunk, when the total size becomes known. Intermediate chunks must
+        get HTTP 308, not 200.
+        """
+        chunk_size = 256 * 1024
+        # More than two chunks so intermediate /* ranges are used.
+        content = b"x" * (chunk_size * 3 + 123)
+        bucket = self._client.create_bucket("testbucket")
+        blob = bucket.blob("chunked-stream.bin", chunk_size=chunk_size)
+
+        with blob.open("wb", chunk_size=chunk_size) as writer:
+            offset = 0
+            while offset < len(content):
+                writer.write(content[offset : offset + chunk_size])
+                offset += chunk_size
+
+        fetched = bucket.get_blob("chunked-stream.bin").download_as_bytes()
+        self.assertEqual(len(fetched), len(content))
+        self.assertEqual(fetched, content)
+
+    def test_resumable_chunked_known_total_via_upload_from_string(self):
+        """Known-size multi-chunk upload (chunk_size smaller than object)."""
+        chunk_size = 256 * 1024
+        content = b"y" * (chunk_size * 2 + 50)
+        bucket = self._client.create_bucket("testbucket")
+        blob = bucket.blob("known-total.bin", chunk_size=chunk_size)
+        blob.upload_from_string(content)
+        fetched = bucket.get_blob("known-total.bin").download_as_bytes()
+        self.assertEqual(fetched, content)
+
     def test_empty_blob(self):
         bucket = self._client.create_bucket("testbucket")
         bucket.blob("empty_blob").open("w").close()


### PR DESCRIPTION
Clients such as google-resumable-media send intermediate chunks as Content-Range: bytes START-END/* until the final size is known. The emulator only matched START-END/TOTAL, treated /* chunks as complete, and returned 200 — causing "Upload has finished" on the next write.

Support both Content-Range forms, return 308 with Range while incomplete, and validate chunk start offsets (#301).