### PR TITLE
Support object and bucket ACLs for make_public / make_private

### DIFF
--- a/src/gcp_storage_emulator/handlers/buckets.py
+++ b/src/gcp_storage_emulator/handlers/buckets.py
@@ -32,6 +32,50 @@ BAD_REQUEST = {
 }
 
 
+_WRITABLE_BUCKET_FIELDS = (
+    "acl",
+    "defaultObjectAcl",
+    "cors",
+    "lifecycle",
+    "location",
+    "storageClass",
+    "versioning",
+    "labels",
+    "website",
+    "billing",
+    "iamConfiguration",
+    "encryption",
+    "logging",
+    "retentionPolicy",
+)
+
+
+def _normalize_bucket_acl_entries(bucket_name, entries, kind):
+    """Normalize client ACL entries for bucket or default object ACLs."""
+    normalized = []
+    for entry in entries or []:
+        if not isinstance(entry, dict):
+            continue
+        entity = entry.get("entity")
+        role = entry.get("role")
+        if not entity or not role:
+            continue
+        item = {
+            "kind": kind,
+            "entity": entity,
+            "role": role,
+            "bucket": bucket_name,
+        }
+        if entry.get("entityId") is not None:
+            item["entityId"] = entry["entityId"]
+        if entry.get("email") is not None:
+            item["email"] = entry["email"]
+        if entry.get("domain") is not None:
+            item["domain"] = entry["domain"]
+        normalized.append(item)
+    return normalized
+
+
 def _make_bucket_resource(bucket_name):
     now = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.%fZ")
     return {
@@ -51,7 +95,31 @@ def _make_bucket_resource(bucket_name):
         "locationType": "multi-region",
         "storageClass": "STANDARD",
         "etag": "CAE=",
+        "acl": [],
+        "defaultObjectAcl": [],
     }
+
+
+def _patch_bucket(bucket, metadata):
+    if not metadata:
+        return bucket
+    bucket["metageneration"] = str(int(bucket.get("metageneration", "1")) + 1)
+    name = bucket.get("name")
+    for key in _WRITABLE_BUCKET_FIELDS:
+        val = metadata.get(key)
+        if val is None:
+            continue
+        if key == "acl":
+            bucket[key] = _normalize_bucket_acl_entries(
+                name, val, "storage#bucketAccessControl"
+            )
+        elif key == "defaultObjectAcl":
+            bucket[key] = _normalize_bucket_acl_entries(
+                name, val, "storage#objectAccessControl"
+            )
+        else:
+            bucket[key] = val
+    return bucket
 
 
 def get(request, response, storage, *args, **kwargs):
@@ -112,3 +180,41 @@ def delete(request, response, storage, *args, **kwargs):
         response.status = HTTPStatus.NOT_FOUND
     except Conflict:
         response.status = HTTPStatus.CONFLICT
+
+
+def patch(request, response, storage, *args, **kwargs):
+    """PATCH /storage/v1/b/{bucket} — update metadata including ACLs."""
+    name = request.params.get("bucket_name")
+    bucket = storage.buckets.get(name) if name else None
+    if not bucket:
+        response.status = HTTPStatus.NOT_FOUND
+        return
+    updated = _patch_bucket(bucket, request.data or {})
+    storage.create_bucket(name, updated)
+    response.json(updated)
+
+
+def acl_list(request, response, storage, *args, **kwargs):
+    """GET /storage/v1/b/{bucket}/acl"""
+    name = request.params.get("bucket_name")
+    bucket = storage.buckets.get(name) if name else None
+    if not bucket:
+        response.status = HTTPStatus.NOT_FOUND
+        return
+    items = _normalize_bucket_acl_entries(
+        name, bucket.get("acl") or [], "storage#bucketAccessControl"
+    )
+    response.json({"kind": "storage#bucketAccessControls", "items": items})
+
+
+def default_object_acl_list(request, response, storage, *args, **kwargs):
+    """GET /storage/v1/b/{bucket}/defaultObjectAcl"""
+    name = request.params.get("bucket_name")
+    bucket = storage.buckets.get(name) if name else None
+    if not bucket:
+        response.status = HTTPStatus.NOT_FOUND
+        return
+    items = _normalize_bucket_acl_entries(
+        name, bucket.get("defaultObjectAcl") or [], "storage#objectAccessControl"
+    )
+    response.json({"kind": "storage#objectAccessControls", "items": items})

--- a/src/gcp_storage_emulator/handlers/objects.py
+++ b/src/gcp_storage_emulator/handlers/objects.py
@@ -19,6 +19,7 @@ from gcp_storage_emulator.exceptions import BadRequest, Conflict, NotFound
 logger = logging.getLogger("api.object")
 
 _WRITABLE_FIELDS = (
+    "acl",
     "cacheControl",
     "contentDisposition",
     "contentEncoding",
@@ -116,7 +117,12 @@ def _patch_object(obj, metadata):
             if val is not None:
                 if key == "customTime" and obj.get(key) and obj.get(key) > val:
                     continue
-                obj[key] = val
+                if key == "acl":
+                    obj[key] = _normalize_object_acl_entries(
+                        obj.get("bucket"), obj.get("name"), val
+                    )
+                else:
+                    obj[key] = val
     return obj
 
 
@@ -149,9 +155,38 @@ def _make_object_resource(
         ),
         "crc32c": None,
         "etag": None,
+        # Object ACLs (used by blob.make_public / make_private).
+        "acl": [],
     }
     obj = _patch_object(obj, metadata)
     return obj
+
+
+def _normalize_object_acl_entries(bucket_name, object_id, entries):
+    """Normalize client ACL entries to GCS objectAccessControl resources."""
+    normalized = []
+    for entry in entries or []:
+        if not isinstance(entry, dict):
+            continue
+        entity = entry.get("entity")
+        role = entry.get("role")
+        if not entity or not role:
+            continue
+        item = {
+            "kind": "storage#objectAccessControl",
+            "entity": entity,
+            "role": role,
+            "bucket": bucket_name,
+            "object": object_id,
+        }
+        if entry.get("entityId") is not None:
+            item["entityId"] = entry["entityId"]
+        if entry.get("email") is not None:
+            item["email"] = entry["email"]
+        if entry.get("domain") is not None:
+            item["domain"] = entry["domain"]
+        normalized.append(item)
+    return normalized
 
 
 def _content_type_from_request(request, default=None):
@@ -675,6 +710,28 @@ def patch(request, response, storage, *args, **kwargs):
         response.json(obj)
     else:
         response.status = HTTPStatus.NOT_FOUND
+
+
+def acl_list(request, response, storage, *args, **kwargs):
+    """List object access controls.
+
+    GET /storage/v1/b/{bucket}/o/{object}/acl
+    https://cloud.google.com/storage/docs/json_api/v1/objectAccessControls/list
+    """
+    bucket_name = request.params["bucket_name"]
+    object_id = request.params["object_id"]
+    try:
+        obj = storage.get_file_obj(bucket_name, object_id)
+    except NotFound:
+        response.status = HTTPStatus.NOT_FOUND
+        return
+    items = _normalize_object_acl_entries(bucket_name, object_id, obj.get("acl") or [])
+    response.json(
+        {
+            "kind": "storage#objectAccessControls",
+            "items": items,
+        }
+    )
 
 
 def _batch_write_json(response, status_line, payload):

--- a/src/gcp_storage_emulator/server.py
+++ b/src/gcp_storage_emulator/server.py
@@ -52,8 +52,16 @@ def _json_api_routes(prefix):
     return (
         (rf"^{p}/b$", {GET: buckets.ls, POST: buckets.insert}),
         (
+            rf"^{p}/b/(?P<bucket_name>[-.\w]+)/acl$",
+            {GET: buckets.acl_list},
+        ),
+        (
+            rf"^{p}/b/(?P<bucket_name>[-.\w]+)/defaultObjectAcl$",
+            {GET: buckets.default_object_acl_list},
+        ),
+        (
             rf"^{p}/b/(?P<bucket_name>[-.\w]+)$",
-            {GET: buckets.get, DELETE: buckets.delete},
+            {GET: buckets.get, DELETE: buckets.delete, PATCH: buckets.patch},
         ),
         (
             rf"^{p}/b/(?P<bucket_name>[-.\w]+)/o$",
@@ -72,6 +80,12 @@ def _json_api_routes(prefix):
         (
             rf"^{p}/b/(?P<bucket_name>[-.\w]+)/o/(?P<object_id>.*[^/]+)/compose$",
             {POST: objects.compose},
+        ),
+        # Object ACL list must be registered before the generic object path so
+        # ``.../o/name/acl`` is not treated as object_id ``name/acl``.
+        (
+            rf"^{p}/b/(?P<bucket_name>[-.\w]+)/o/(?P<object_id>.*[^/]+)/acl$",
+            {GET: objects.acl_list},
         ),
         (
             rf"^{p}/b/(?P<bucket_name>[-.\w]+)/o/(?P<object_id>.*[^/]+)$",

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1120,6 +1120,63 @@ class ObjectsTests(ServerBaseCase):
         names = [item["name"] for item in listed.json().get("items", [])]
         self.assertIn("alias.txt", names)
 
+    def test_blob_make_public_and_make_private(self):
+        """Python blob.make_public / make_private (issue #204).
+
+        These call GET .../o/{object}/acl then PATCH the object with an acl list
+        that grants or revokes allUsers READER.
+        """
+        bucket = self._client.create_bucket("acl-bucket")
+        blob = bucket.blob("public-me.txt")
+        blob.upload_from_string("hello-acl")
+
+        # Empty ACL list before make_public.
+        listed = self._session.get(
+            "http://localhost:9023/storage/v1/b/acl-bucket/o/public-me.txt/acl",
+            timeout=5,
+        )
+        self.assertEqual(listed.status_code, 200, listed.text)
+        self.assertEqual(listed.json().get("kind"), "storage#objectAccessControls")
+        self.assertEqual(listed.json().get("items"), [])
+
+        blob.make_public()
+        entities = {entry["entity"]: entry["role"] for entry in blob.acl}
+        self.assertEqual(entities.get("allUsers"), "READER")
+
+        # Persist check via raw API.
+        after = self._session.get(
+            "http://localhost:9023/storage/v1/b/acl-bucket/o/public-me.txt/acl",
+            timeout=5,
+        )
+        self.assertEqual(after.status_code, 200, after.text)
+        raw_entities = {
+            item["entity"]: item["role"] for item in after.json().get("items", [])
+        }
+        self.assertEqual(raw_entities.get("allUsers"), "READER")
+
+        blob.make_private()
+        entities_private = {entry["entity"]: entry["role"] for entry in blob.acl}
+        self.assertNotIn("allUsers", entities_private)
+
+        # Content still readable after ACL changes.
+        self.assertEqual(blob.download_as_bytes(), b"hello-acl")
+
+    def test_bucket_make_public(self):
+        """Bucket.make_public uses GET .../acl + PATCH bucket with acl."""
+        bucket = self._client.create_bucket("bucket-acl")
+        blob = bucket.blob("nested.txt")
+        blob.upload_from_string("data")
+
+        bucket.make_public()
+        bucket_entities = {entry["entity"]: entry["role"] for entry in bucket.acl}
+        self.assertEqual(bucket_entities.get("allUsers"), "READER")
+
+        # future=True also touches defaultObjectAcl.
+        bucket2 = self._client.create_bucket("bucket-acl-future")
+        bucket2.make_public(future=True)
+        doa = {entry["entity"]: entry["role"] for entry in bucket2.default_object_acl}
+        self.assertEqual(doa.get("allUsers"), "READER")
+
     def test_upload_without_upload_prefix_does_not_crash(self):
         """Wrong path /storage/v1/.../o?uploadType= used by some clients (#258).
 


### PR DESCRIPTION
Fixes #204

Python blob.make_public() loads GET .../o/{object}/acl then PATCHes the object with an acl list (allUsers READER). Register object ACL list routes before the generic object path, store acl on objects, and accept acl on PATCH. Also implement bucket ACL / defaultObjectAcl list and bucket PATCH so Bucket.make_public works.