### PR TITLE
Stub bucket IAM get/set/testPermissions for client compatibility

### DIFF
--- a/src/gcp_storage_emulator/handlers/buckets.py
+++ b/src/gcp_storage_emulator/handlers/buckets.py
@@ -218,3 +218,77 @@ def default_object_acl_list(request, response, storage, *args, **kwargs):
         name, bucket.get("defaultObjectAcl") or [], "storage#objectAccessControl"
     )
     response.json({"kind": "storage#objectAccessControls", "items": items})
+
+
+def _default_iam_policy(bucket_name):
+    """Stub default IAM policy (stored only; not enforced)."""
+    return {
+        "kind": "storage#policy",
+        "resourceId": "projects/_/buckets/{}".format(bucket_name),
+        "version": 1,
+        "etag": "CAE=",
+        "bindings": [],
+    }
+
+
+def _policy_response(bucket_name, policy):
+    """Ensure policy response has required GCS fields."""
+    out = dict(policy or {})
+    out["kind"] = "storage#policy"
+    out["resourceId"] = "projects/_/buckets/{}".format(bucket_name)
+    if "version" not in out:
+        out["version"] = 1
+    if "etag" not in out:
+        out["etag"] = "CAE="
+    if "bindings" not in out:
+        out["bindings"] = []
+    return out
+
+
+def get_iam_policy(request, response, storage, *args, **kwargs):
+    """GET /storage/v1/b/{bucket}/iam — store/return only, not enforced (#229)."""
+    name = request.params.get("bucket_name")
+    if not name or name not in storage.buckets:
+        response.status = HTTPStatus.NOT_FOUND
+        return
+    policy = storage.get_bucket_iam_policy(name)
+    if policy is None:
+        policy = _default_iam_policy(name)
+        storage.set_bucket_iam_policy(name, policy)
+    # optionsRequestedPolicyVersion is accepted and ignored (no conditions).
+    response.json(_policy_response(name, policy))
+
+
+def set_iam_policy(request, response, storage, *args, **kwargs):
+    """PUT /storage/v1/b/{bucket}/iam — store policy JSON only (#229)."""
+    name = request.params.get("bucket_name")
+    if not name or name not in storage.buckets:
+        response.status = HTTPStatus.NOT_FOUND
+        return
+    body = request.data if isinstance(request.data, dict) else {}
+    # Keep client bindings/version/etag; fill in resource identity fields.
+    policy = {
+        "kind": "storage#policy",
+        "resourceId": "projects/_/buckets/{}".format(name),
+        "version": body.get("version", 1),
+        "etag": body.get("etag") or "CAI=",
+        "bindings": body.get("bindings") if body.get("bindings") is not None else [],
+    }
+    storage.set_bucket_iam_policy(name, policy)
+    response.json(_policy_response(name, policy))
+
+
+def test_iam_permissions(request, response, storage, *args, **kwargs):
+    """GET /storage/v1/b/{bucket}/iam/testPermissions — stub: allow all requested."""
+    name = request.params.get("bucket_name")
+    if not name or name not in storage.buckets:
+        response.status = HTTPStatus.NOT_FOUND
+        return
+    # Query may repeat permissions=...; parse_qs returns a list.
+    permissions = request.query.get("permissions") or []
+    response.json(
+        {
+            "kind": "storage#testIamPermissionsResponse",
+            "permissions": list(permissions),
+        }
+    )

--- a/src/gcp_storage_emulator/server.py
+++ b/src/gcp_storage_emulator/server.py
@@ -59,6 +59,15 @@ def _json_api_routes(prefix):
             rf"^{p}/b/(?P<bucket_name>[-.\w]+)/defaultObjectAcl$",
             {GET: buckets.default_object_acl_list},
         ),
+        # IAM stubs (#229): more specific paths before /b/{bucket}
+        (
+            rf"^{p}/b/(?P<bucket_name>[-.\w]+)/iam/testPermissions$",
+            {GET: buckets.test_iam_permissions},
+        ),
+        (
+            rf"^{p}/b/(?P<bucket_name>[-.\w]+)/iam$",
+            {GET: buckets.get_iam_policy, PUT: buckets.set_iam_policy},
+        ),
         (
             rf"^{p}/b/(?P<bucket_name>[-.\w]+)$",
             {GET: buckets.get, DELETE: buckets.delete, PATCH: buckets.patch},

--- a/src/gcp_storage_emulator/storage.py
+++ b/src/gcp_storage_emulator/storage.py
@@ -188,6 +188,7 @@ class Storage:
             "buckets": self.buckets,
             "objects": self.objects,
             "resumable": self.resumable,
+            "bucket_iam_policies": self.bucket_iam_policies,
         }
         self._store.write_bytes(".meta", json.dumps(data, indent=2).encode("utf-8"))
 
@@ -198,11 +199,13 @@ class Storage:
             self.buckets = {}
             self.objects = {}
             self.resumable = {}
+            self.bucket_iam_policies = {}
             return
         data = json.loads(raw.decode("utf-8"))
-        self.buckets = data.get("buckets")
-        self.objects = data.get("objects")
-        self.resumable = data.get("resumable")
+        self.buckets = data.get("buckets") or {}
+        self.objects = data.get("objects") or {}
+        self.resumable = data.get("resumable") or {}
+        self.bucket_iam_policies = data.get("bucket_iam_policies") or {}
 
     def _object_path(self, bucket_name, file_name):
         file_name = file_name.replace("\\", "/").lstrip("/")
@@ -508,9 +511,24 @@ class Storage:
             )
 
         del self.buckets[bucket_name]
+        self.bucket_iam_policies.pop(bucket_name, None)
 
         self._delete_dir(bucket_name)
         self._write_config_to_file()
+
+    def get_bucket_iam_policy(self, bucket_name):
+        """Return stored IAM policy for a bucket, or None if bucket missing."""
+        if bucket_name not in self.buckets:
+            return None
+        return self.bucket_iam_policies.get(bucket_name)
+
+    def set_bucket_iam_policy(self, bucket_name, policy):
+        """Store IAM policy for a bucket. Returns False if bucket missing."""
+        if bucket_name not in self.buckets:
+            return False
+        self.bucket_iam_policies[bucket_name] = policy
+        self._write_config_to_file()
+        return True
 
     def delete_file(self, bucket_name, file_name):
         try:
@@ -541,9 +559,11 @@ class Storage:
 
     def wipe(self, keep_buckets=False):
         existing_buckets = self.buckets
+        existing_iam = dict(self.bucket_iam_policies) if keep_buckets else {}
         self.buckets = {}
         self.objects = {}
         self.resumable = {}
+        self.bucket_iam_policies = {}
 
         try:
             self._store.remove_file(".meta")
@@ -558,6 +578,9 @@ class Storage:
         if keep_buckets:
             for bucket_name, bucket_obj in existing_buckets.items():
                 self.create_bucket(bucket_name, bucket_obj)
+                if bucket_name in existing_iam:
+                    self.bucket_iam_policies[bucket_name] = existing_iam[bucket_name]
+            self._write_config_to_file()
 
     def patch_object(self, bucket_name, file_name, file_obj):
         """Patch object

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1177,6 +1177,61 @@ class ObjectsTests(ServerBaseCase):
         doa = {entry["entity"]: entry["role"] for entry in bucket2.default_object_acl}
         self.assertEqual(doa.get("allUsers"), "READER")
 
+    def test_bucket_get_and_set_iam_policy(self):
+        """Bucket IAM getIamPolicy / setIamPolicy stubs (issue #229).
+
+        Policies are stored and returned only; permissions are not enforced.
+        """
+        bucket = self._client.create_bucket("iam-bucket")
+
+        # Default empty policy via Python client.
+        policy = bucket.get_iam_policy(requested_policy_version=3)
+        self.assertIsNotNone(policy)
+        self.assertEqual(policy.to_api_repr().get("bindings", []), [])
+
+        # Raw GET also works (and unprefixed /b alias).
+        raw = self._session.get(
+            "http://localhost:9023/storage/v1/b/iam-bucket/iam", timeout=5
+        )
+        self.assertEqual(raw.status_code, 200, raw.text)
+        self.assertEqual(raw.json().get("kind"), "storage#policy")
+        self.assertEqual(raw.json().get("resourceId"), "projects/_/buckets/iam-bucket")
+
+        alias = self._session.get("http://localhost:9023/b/iam-bucket/iam", timeout=5)
+        self.assertEqual(alias.status_code, 200, alias.text)
+
+        # Set a binding and read it back.
+        policy = bucket.get_iam_policy(requested_policy_version=3)
+        policy["roles/storage.objectViewer"] = {"allUsers"}
+        updated = bucket.set_iam_policy(policy)
+        roles = {
+            b["role"]: set(b["members"])
+            for b in updated.to_api_repr().get("bindings", [])
+        }
+        self.assertIn("allUsers", roles.get("roles/storage.objectViewer", set()))
+
+        again = bucket.get_iam_policy(requested_policy_version=3)
+        roles2 = {
+            b["role"]: set(b["members"])
+            for b in again.to_api_repr().get("bindings", [])
+        }
+        self.assertIn("allUsers", roles2.get("roles/storage.objectViewer", set()))
+
+        missing = self._session.get(
+            "http://localhost:9023/storage/v1/b/no-such-bucket/iam", timeout=5
+        )
+        self.assertEqual(missing.status_code, 404)
+
+    def test_bucket_test_iam_permissions_stub(self):
+        """testIamPermissions returns the requested permissions (allow-all stub)."""
+        bucket = self._client.create_bucket("iam-perms-bucket")
+        perms = [
+            "storage.buckets.get",
+            "storage.objects.create",
+        ]
+        allowed = bucket.test_iam_permissions(perms)
+        self.assertEqual(set(allowed), set(perms))
+
     def test_upload_without_upload_prefix_does_not_crash(self):
         """Wrong path /storage/v1/.../o?uploadType= used by some clients (#258).
 


### PR DESCRIPTION
Fixes #229

Store IAM policy JSON per bucket without enforcing it. Implement GET/PUT .../b/{bucket}/iam and GET .../iam/testPermissions (allow-all) under both /storage/v1 and unprefixed /b paths so Python get_iam_policy / set_iam_policy / test_iam_permissions work in tests.