### PR TITLE
Make bucket projectNumber configurable via env and CLI

### DIFF
--- a/src/gcp_storage_emulator/__main__.py
+++ b/src/gcp_storage_emulator/__main__.py
@@ -7,6 +7,7 @@ import sys
 
 from gcp_storage_emulator.handlers.buckets import create_bucket
 from gcp_storage_emulator.server import create_server
+from gcp_storage_emulator.settings import DEFAULT_PROJECT_NUMBER
 from gcp_storage_emulator.storage import Storage
 
 # One after gcloud-task-emulator one
@@ -14,8 +15,22 @@ DEFAULT_PORT = int(os.environ.get("PORT", 9023))
 DEFAULT_HOST = os.environ.get("HOST", "localhost")
 
 
-def get_server(host, port, memory=False, default_bucket=None, data_dir=None):
-    server = create_server(host, port, memory, default_bucket, data_dir=data_dir)
+def get_server(
+    host,
+    port,
+    memory=False,
+    default_bucket=None,
+    data_dir=None,
+    project_number=None,
+):
+    server = create_server(
+        host,
+        port,
+        memory,
+        default_bucket,
+        data_dir=data_dir,
+        project_number=project_number,
+    )
     return server
 
 
@@ -45,6 +60,14 @@ def prepare_args_parser():
     start.add_argument(
         "--default-bucket",
         help="The default bucket. If provided, bucket will be created automatically",
+    )
+    start.add_argument(
+        "--project-number",
+        default=DEFAULT_PROJECT_NUMBER,
+        help=(
+            "Project number reported on bucket resources (default: env "
+            "PROJECT_NUMBER or 1234)"
+        ),
     )
     start.add_argument(
         "-q",
@@ -110,7 +133,12 @@ def main(args=sys.argv[1:], test_mode=False):
     else:
         root.setLevel(logging.DEBUG)
     server = get_server(
-        args.host, args.port, args.no_store_on_disk, args.default_bucket, args.data_dir
+        args.host,
+        args.port,
+        args.no_store_on_disk,
+        args.default_bucket,
+        args.data_dir,
+        project_number=args.project_number,
     )
     if test_mode:
         return server

--- a/src/gcp_storage_emulator/handlers/buckets.py
+++ b/src/gcp_storage_emulator/handlers/buckets.py
@@ -76,13 +76,15 @@ def _normalize_bucket_acl_entries(bucket_name, entries, kind):
     return normalized
 
 
-def _make_bucket_resource(bucket_name):
+def _make_bucket_resource(bucket_name, project_number=None):
     now = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.%fZ")
+    if project_number is None:
+        project_number = settings.DEFAULT_PROJECT_NUMBER
     return {
         "kind": "storage#bucket",
         "id": bucket_name,
         "selfLink": "{}/b/{}".format(settings.API_ENDPOINT, bucket_name),
-        "projectNumber": "1234",
+        "projectNumber": str(project_number),
         "name": bucket_name,
         "timeCreated": now,
         "updated": now,
@@ -144,7 +146,10 @@ def create_bucket(name, storage):
     if storage.get_bucket(name):
         return False
     else:
-        bucket = _make_bucket_resource(name)
+        project_number = getattr(
+            storage, "project_number", settings.DEFAULT_PROJECT_NUMBER
+        )
+        bucket = _make_bucket_resource(name, project_number=project_number)
         storage.create_bucket(name, bucket)
         return bucket
 
@@ -160,8 +165,6 @@ def insert(request, response, storage, *args, **kwargs):
             response.status = HTTPStatus.CONFLICT
             response.json(CONFLICT)
         else:
-            bucket = _make_bucket_resource(name)
-            storage.create_bucket(name, bucket)
             response.json(bucket)
     else:
         response.status = HTTPStatus.BAD_REQUEST

--- a/src/gcp_storage_emulator/server.py
+++ b/src/gcp_storage_emulator/server.py
@@ -501,8 +501,20 @@ class APIThread(threading.Thread):
 
 
 class Server(object):
-    def __init__(self, host, port, in_memory, default_bucket=None, data_dir=None):
-        self._storage = Storage(use_memory_fs=in_memory, data_dir=data_dir)
+    def __init__(
+        self,
+        host,
+        port,
+        in_memory,
+        default_bucket=None,
+        data_dir=None,
+        project_number=None,
+    ):
+        self._storage = Storage(
+            use_memory_fs=in_memory,
+            data_dir=data_dir,
+            project_number=project_number,
+        )
         if default_bucket:
             logger.debug('[SERVER] Creating default bucket "{}"'.format(default_bucket))
             buckets.create_bucket(default_bucket, self._storage)
@@ -542,7 +554,14 @@ class Server(object):
             self.stop()
 
 
-def create_server(host, port, in_memory=False, default_bucket=None, data_dir=None):
+def create_server(
+    host,
+    port,
+    in_memory=False,
+    default_bucket=None,
+    data_dir=None,
+    project_number=None,
+):
     logger.info("Starting server at {}:{}".format(host, port))
     return Server(
         host,
@@ -550,4 +569,5 @@ def create_server(host, port, in_memory=False, default_bucket=None, data_dir=Non
         in_memory=in_memory,
         default_bucket=default_bucket,
         data_dir=data_dir,
+        project_number=project_number,
     )

--- a/src/gcp_storage_emulator/settings.py
+++ b/src/gcp_storage_emulator/settings.py
@@ -8,3 +8,7 @@ DOWNLOAD_API_ENDPOINT = "/download/storage/v1"
 # Disk storage is rooted at STORAGE_BASE / STORAGE_DIR
 STORAGE_BASE = os.path.abspath(os.environ.get("STORAGE_BASE", "./"))
 STORAGE_DIR = os.environ.get("STORAGE_DIR", ".cloudstorage")
+
+# Default GCP-style project number on bucket resources (issue #118).
+# Override with env PROJECT_NUMBER or --project-number / create_server(...).
+DEFAULT_PROJECT_NUMBER = os.environ.get("PROJECT_NUMBER", "1234")

--- a/src/gcp_storage_emulator/storage.py
+++ b/src/gcp_storage_emulator/storage.py
@@ -9,7 +9,11 @@ from typing import Dict, List, Optional, Set
 
 from gcp_storage_emulator.exceptions import BadRequest, Conflict, NotFound
 from gcp_storage_emulator.gcs_glob import gcs_glob_match
-from gcp_storage_emulator.settings import STORAGE_BASE, STORAGE_DIR
+from gcp_storage_emulator.settings import (
+    DEFAULT_PROJECT_NUMBER,
+    STORAGE_BASE,
+    STORAGE_DIR,
+)
 
 # Real buckets can't start with an underscore
 RESUMABLE_DIR = "_resumable"
@@ -166,7 +170,7 @@ class _FileStore:
 
 
 class Storage:
-    def __init__(self, use_memory_fs=False, data_dir=None):
+    def __init__(self, use_memory_fs=False, data_dir=None, project_number=None):
         if not data_dir:
             data_dir = STORAGE_BASE
         if not os.path.isabs(data_dir):
@@ -174,6 +178,10 @@ class Storage:
 
         self._data_dir = data_dir
         self._use_memory_fs = use_memory_fs
+        # Used when creating new bucket resources (issue #118).
+        if project_number is None:
+            project_number = DEFAULT_PROJECT_NUMBER
+        self.project_number = str(project_number)
         if use_memory_fs:
             self._store = _FileStore(use_memory=True)
         else:

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -175,6 +175,116 @@ class DefaultBucketTests(BaseTestCase):
         self.assertEqual(bucket.storage_class, "STANDARD")
 
 
+class ProjectNumberConfigTests(BaseTestCase):
+    """Configurable projectNumber on bucket resources (issue #118)."""
+
+    def tearDown(self):
+        if getattr(self, "_server", None):
+            self._server.wipe()
+            self._server.stop()
+        return super().tearDown()
+
+    def _start(self, port, **kwargs):
+        self._server = create_server("localhost", port, in_memory=True, **kwargs)
+        self._server.start()
+        self._session = requests.Session()
+        os.environ["STORAGE_EMULATOR_HOST"] = "http://localhost:{}".format(port)
+        from google.cloud import storage
+
+        return storage.Client(
+            project="[PROJECT]",
+            _http=self._session,
+            client_options={"api_endpoint": "http://localhost:{}".format(port)},
+        )
+
+    def test_create_server_project_number_kwarg(self):
+        client = self._start(19051, project_number="987654321012")
+        bucket = client.create_bucket("pn-kwarg-bucket")
+        self.assertEqual(bucket.project_number, 987654321012)
+        # Raw JSON field is a string, same as GCS.
+        raw = self._session.get(
+            "http://localhost:19051/storage/v1/b/pn-kwarg-bucket", timeout=5
+        )
+        self.assertEqual(raw.status_code, 200)
+        self.assertEqual(raw.json()["projectNumber"], "987654321012")
+
+    def test_default_bucket_uses_project_number(self):
+        client = self._start(
+            19052,
+            default_bucket="default-pn.appspot.com",
+            project_number="111222333444",
+        )
+        bucket = client.get_bucket("default-pn.appspot.com")
+        self.assertEqual(bucket.project_number, 111222333444)
+
+    def test_project_number_env_default(self):
+        """PROJECT_NUMBER env is read into settings at import; Storage uses
+        DEFAULT_PROJECT_NUMBER when project_number is omitted.
+
+        We pass the value explicitly via create_server to avoid mutating
+        module globals mid-suite; env is covered by argparse default tests.
+        """
+        from gcp_storage_emulator import settings
+        from gcp_storage_emulator.storage import Storage
+
+        storage = Storage(use_memory_fs=True, project_number=None)
+        self.assertEqual(storage.project_number, str(settings.DEFAULT_PROJECT_NUMBER))
+
+        storage_custom = Storage(use_memory_fs=True, project_number="555666777888")
+        self.assertEqual(storage_custom.project_number, "555666777888")
+
+
+class ProjectNumberCliTests(BaseTestCase):
+    def test_cli_project_number_argument(self):
+        from gcp_storage_emulator.__main__ import prepare_args_parser
+
+        parser, _ = prepare_args_parser()
+        args = parser.parse_args(
+            ["start", "--port=19053", "--project-number=424242424242"]
+        )
+        self.assertEqual(args.project_number, "424242424242")
+
+    def test_cli_project_number_default_from_settings(self):
+        from gcp_storage_emulator.__main__ import prepare_args_parser
+        from gcp_storage_emulator.settings import DEFAULT_PROJECT_NUMBER
+
+        parser, _ = prepare_args_parser()
+        args = parser.parse_args(["start", "--port=19054"])
+        self.assertEqual(args.project_number, DEFAULT_PROJECT_NUMBER)
+
+    def test_settings_default_matches_env_or_1234(self):
+        from gcp_storage_emulator.settings import DEFAULT_PROJECT_NUMBER
+
+        self.assertEqual(
+            DEFAULT_PROJECT_NUMBER, os.environ.get("PROJECT_NUMBER", "1234")
+        )
+
+    def test_main_start_passes_project_number(self):
+        from gcp_storage_emulator.__main__ import main
+
+        server = main(
+            ["start", "--port=19055", "--in-memory", "--project-number=121212121212"],
+            test_mode=True,
+        )
+        try:
+            server.start()
+            self.assertEqual(server._storage.project_number, "121212121212")
+            session = requests.Session()
+            os.environ["STORAGE_EMULATOR_HOST"] = "http://localhost:19055"
+            from google.cloud import storage
+
+            client = storage.Client(
+                project="[PROJECT]",
+                _http=session,
+                client_options={"api_endpoint": "http://localhost:19055"},
+            )
+            bucket = client.create_bucket("cli-pn-bucket")
+            self.assertEqual(bucket.project_number, 121212121212)
+        finally:
+            server.wipe()
+            server.stop()
+
+
 class ObjectsTests(ServerBaseCase):
     def test_upload_from_string(self):
         content = "this is the content of the file\n"


### PR DESCRIPTION
Fixes #118

Default remains 1234. Override with PROJECT_NUMBER env, --project-number on start, or create_server(..., project_number=...). New buckets use the configured value; also fix insert double-create so the stored resource is returned as-is.